### PR TITLE
corregir palabra link

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <limnk rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.css">
   <title>Walsh</title>
 </head>
 
@@ -47,7 +47,7 @@
   </p>
   <p>
     Parece que la sal
-    
+
     Siempre negra fue<br>
     Y de un susto se puso blanca
     Tal como la ven,


### PR DESCRIPTION
La palabra link estaba mal escrita 